### PR TITLE
Remove reference to papagal

### DIFF
--- a/docs/guidelines.md
+++ b/docs/guidelines.md
@@ -59,4 +59,3 @@
   - Verify the author of extensions is a reputable entity. Some extensions that can be trusted:
     - Facebook Container (from Mozilla)
     - uBlock Origin
-    - papagal (self authored)


### PR DESCRIPTION
No longer relevant since the demise of Flowdock.